### PR TITLE
Add support for FreeBSD

### DIFF
--- a/gl/bindings.lisp
+++ b/gl/bindings.lisp
@@ -103,7 +103,7 @@
 ;;; Fallback get-proc-address bindings which should work for common
 ;;; configurations
 ;;; TODO: Darwin
-#+linux
+#+(or linux freebsd)
 (defcfun ("glXGetProcAddress" glx-get-proc-address) :pointer
   (proc-name :string))
 #+windows
@@ -112,7 +112,7 @@
 
 (defun gl-get-proc-address (name)
   (funcall (or *gl-get-proc-address*
-               #+linux #'glx-get-proc-address
+               #+(or linux freebsd) #'glx-get-proc-address
                #+windows #'wgl-get-proc-address
                #'cffi:foreign-symbol-pointer)
            name))


### PR DESCRIPTION
Make `gl-get-proc-address` work on FreeBSD which atm fails with:

```
Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {100301E933}>
0: (SB-KERNEL:%COERCE-CALLABLE-TO-FUN NIL)
1: (CL-OPENGL-BINDINGS::GL-GET-PROC-ADDRESS "glGetStringi")
2: (CL-OPENGL-BINDINGS::GENERATE-GL-FUNCTION "glGetStringi" CL-OPENGL-BINDINGS:GET-
STRING-I CL-OPENGL-BINDINGS:STRING ((CL-OPENGL-BINDINGS::NAME CL-OPENGL-BINDINGS:ENUM) 
(CL-OPENGL-BINDINGS::INDEX CL-OPENGL-BINDINGS:UINT)) :EXTENSIONS 0)
3: (GET-GL-EXTENSIONS)
4: (CEPL-POST-CONTEXT-INITIALIZE)
5: (%REPL 640 480)
6: (SB-INT:SIMPLE-EVAL-IN-LEXENV (REPL) #<NULL-LEXENV>)
7: (EVAL (REPL))
8: (SB-EXT:INTERACTIVE-EVAL (REPL) :EVAL NIL)
9: (SB-IMPL::REPL-FUN NIL)```